### PR TITLE
Pre-install Babashka

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,3 +23,9 @@ RUN mkdir -p $HOME/bin && \
 	echo "(defproject dummy \"\" :dependencies [[org.clojure/clojure \"${CLOJURE_VERSION}\"]])" > project.clj && \
 	lein deps && \
 	rm -r project.clj target/
+
+# Install tooling
+ENV BABASHKA_VERSION=0.7.4
+RUN curl -sSL "https://github.com/babashka/babashka/releases/download/v0.7.4/babashka-0.7.4-linux-amd64-static.tar.gz" \
+	| sudo tar -xz -C /usr/local/bin/ && \
+	bb --version

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ You can now use Clojure within the steps for this job.
 This image contains the Clojure programming language as installed via [Leiningen](https://leiningen.org/).
 These Clojure images will contain OpenJDK v17.
 
+Babashka is pre-installed.
+Please note that Babashka has frequent releases while CircleCI only releases Clojure images as the upstream project makes a release.
+There will be times were the pre-installed version of Babashka is older than you might want.
+
 ### Variants
 
 This image will have a Node.js variant in the future.


### PR DESCRIPTION
Closes #14.

Babashka is:

- popular among Clojure users
- is used within CircleCI projects at CircleCI itself
- and they use CircleCI

Feels like good synergy here.