### PR TITLE
Add javahome/bin to PATH

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,7 +4,8 @@ FROM cimg/%%PARENT%%:%%PARENT_TAG%%
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 
-ENV CLOJURE_VERSION=%%VERSION_FULL%%
+ENV CLOJURE_VERSION=%%VERSION_FULL%% \
+	PATH=$JAVA_HOME/bin:$PATH
 
 # Setup the primary install method for Clojure, using CLJ. It unfortunately
 # requires the Clojure version as well as the build number (?), thus a


### PR DESCRIPTION
Closes #34 

Adds `$JAVA_HOME/bin` to `PATH`. Keeps it inline with the legacy image, and honestly just makes sense for this image anyway.