### PR TITLE
Properly use the Babashka envar

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -25,7 +25,7 @@ RUN mkdir -p $HOME/bin && \
 	rm -r project.clj target/
 
 # Install tooling
-ENV BABASHKA_VERSION=0.9.161
-RUN curl -sSL "https://github.com/babashka/babashka/releases/download/v0.7.4/babashka-0.7.4-linux-amd64-static.tar.gz" \
+ENV BABASHKA_VERSION=0.10.163
+RUN curl -sSL "https://github.com/babashka/babashka/releases/download/v${BABASHKA_VERSION}/babashka-${BABASHKA_VERSION}-linux-amd64-static.tar.gz" \
 	| sudo tar -xz -C /usr/local/bin/ && \
 	bb --version


### PR DESCRIPTION
We weren't even using the version envar to set the version to download. This PR fixes that and updates the version.