### PR TITLE
Add jdk21.0 build

### DIFF
--- a/1.11/21.0/Dockerfile
+++ b/1.11/21.0/Dockerfile
@@ -1,0 +1,32 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/openjdk:21.0
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+ENV CLOJURE_VERSION=1.11.1 \
+	PATH=$JAVA_HOME/bin:$PATH
+
+# Setup the primary install method for Clojure, using CLJ. It unfortunately
+# requires the Clojure version as well as the build number (?), thus a
+# parameter (param1) is used.
+RUN curl -sSL -o clojure-installer.sh "https://download.clojure.org/install/linux-install-1.11.1.1200.sh" && \
+	chmod +x clojure-installer.sh && \
+	sudo ./clojure-installer.sh && \
+	rm clojure-installer.sh
+
+ENV LEIN_VERSION=2.9.10
+RUN mkdir -p $HOME/bin && \
+	# the above line can go in the next base image update
+	curl -sSL -o $HOME/bin/lein "https://raw.githubusercontent.com/technomancy/leiningen/${LEIN_VERSION}/bin/lein" && \
+	chmod +x $HOME/bin/lein && \
+	# Finish lein install & Pre-install Clojure
+	echo "(defproject dummy \"\" :dependencies [[org.clojure/clojure \"${CLOJURE_VERSION}\"]])" > project.clj && \
+	lein deps && \
+	rm -r project.clj target/
+
+# Install tooling
+ENV BABASHKA_VERSION=0.10.163
+RUN curl -sSL "https://github.com/babashka/babashka/releases/download/v${BABASHKA_VERSION}/babashka-${BABASHKA_VERSION}-linux-amd64-static.tar.gz" \
+	| sudo tar -xz -C /usr/local/bin/ && \
+	bb --version

--- a/1.11/21.0/browsers/Dockerfile
+++ b/1.11/21.0/browsers/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/clojure:1.11.1-openjdk-21.0-node
+
+LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Install Selenium
+ENV SELENIUM_VER=3.141.59
+RUN curl -sSL -o selenium-server-standalone-${SELENIUM_VER}.jar "https://selenium-release.storage.googleapis.com/${SELENIUM_VER%.*}/selenium-server-standalone-${SELENIUM_VER}.jar" && \
+    sudo cp selenium-server-standalone-${SELENIUM_VER}.jar /usr/local/bin/selenium.jar && \
+    rm selenium-server-standalone-${SELENIUM_VER}.jar
+
+RUN sudo apt-get update && \
+	sudo apt-get install --yes --no-install-recommends \
+		xvfb \
+	&& \
+
+    # Install Java only if it's not already available
+    # Java is installed for Selenium
+    if ! command -v java > /dev/null; then \
+        echo "Java not found in parent image, installing..." && \
+        sudo apt-get install -y --no-install-recommends --no-upgrade openjdk-11-jre; \
+    fi && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+# Below is setup to allow xvfb to start when the container starts up.
+# The label in particular allows this image to override what CircleCI does
+# when booting the image.
+LABEL com.circleci.preserve-entrypoint=true
+ENV DISPLAY=":99"
+#RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint && \
+#	chmod +x /tmp/entrypoint && \
+#	sudo mv /tmp/entrypoint /docker-entrypoint.sh
+RUN	printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' | sudo tee /docker-entrypoint.sh && \
+	sudo chmod +x /docker-entrypoint.sh
+
+# Install a single version of Firefox. This isn't intended to be a regularly
+# updated thing. Instead, if this version of Firefox isn't what the end user
+# wants they should install a different version via the Browser Tools Orb.
+#
+# Canonical made a major technology change in how Firefox is installed from
+# Ubuntu 21.10 and up. The general CI space doesn't seem to be ready for a snap
+# based Firefox right now so we are installing it from the Mozilla PPA.
+RUN echo 'Package: *' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin: release o=LP-PPA-mozillateam' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	echo 'Pin-Priority: 1001' | sudo tee -a /etc/apt/preferences.d/firefox.pref && \
+	sudo add-apt-repository --yes ppa:mozillateam/ppa && \
+	sudo apt-get install --no-install-recommends --yes firefox && \
+	sudo rm -rf /var/lib/apt/lists/* && \
+	firefox --version
+
+# Install a single version of Google Chrome Stable. This isn't intended to be a
+# regularly updated thing. Instead, if this version of Chrome isn't what the
+# end user wants they should install a different version via the Browser Tools
+# Orb.
+RUN wget -q -O - "https://dl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - && \
+	echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list && \
+	sudo apt-get update && \
+	sudo apt-get install google-chrome-stable && \
+	sudo rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/1.11/21.0/node/Dockerfile
+++ b/1.11/21.0/node/Dockerfile
@@ -1,0 +1,20 @@
+# vim:set ft=dockerfile:
+
+FROM cimg/clojure:1.11.1-openjdk-21.0
+
+LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
+
+# Dockerfile will pull the latest LTS release from cimg-node.
+RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/cimg-node/main/ALIASES" -o nodeAliases.txt && \
+	NODE_VERSION=$(grep "lts" ./nodeAliases.txt | cut -d "=" -f 2-) && \
+	curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+	sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1 && \
+	rm node.tar.xz nodeAliases.txt && \
+	sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.22.18
+RUN curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz" && \
+	sudo tar -xzf yarn.tar.gz -C /opt/ && \
+	rm yarn.tar.gz && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
+	sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![CircleCI Build Status](https://circleci.com/gh/CircleCI-Public/cimg-clojure.svg?style=shield)](https://circleci.com/gh/CircleCI-Public/cimg-clojure) [![Software License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/CircleCI-Public/cimg-clojure/main/LICENSE) [![Docker Pulls](https://img.shields.io/docker/pulls/cimg/clojure)](https://hub.docker.com/r/cimg/clojure) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/circleci-images)
 
-***This image is designed to supercede the original CircleCI Clojure image, `circleci/clojure`.***
+**_This image is designed to supercede the original CircleCI Clojure image, `circleci/clojure`._**
 
 `cimg/clojure` is a Docker image created by CircleCI with continuous integration builds in mind.
 Each tag contains a Clojure version, a JVM, and any binaries and tools that are required for builds to complete successfully in a CircleCI environment.
@@ -27,7 +27,6 @@ The CircleCI Docker Convenience Image support policy can be found on the [Circle
 - [Contributing](#contributing)
 - [Additional Resources](#additional-resources)
 - [License](#license)
-
 
 ## Getting Started
 
@@ -48,7 +47,6 @@ In the above example, the CircleCI Clojure Docker image is used for the primary 
 More specifically, the tag `1.10.3` is used meaning the version of Clojure will be Clojure v1.10.3.
 You can now use Clojure within the steps for this job.
 
-
 ## How This Image Works
 
 This image contains the Clojure programming language as installed via clj as well as [Leiningen](https://leiningen.org/).
@@ -61,7 +59,7 @@ There will be times were the pre-installed version of Babashka is older than you
 ### Parent Tags and Parent Slugs
 
 Parent Tags introduce the ability to choose a specific version to include in the tag. In conjunction with
-the Parent Slug, Clojure now supports choosing which OpenJDK version to use and looks like: `parentSlug-parentTag`, which would translate to `openjdk-8.0` 
+the Parent Slug, Clojure now supports choosing which OpenJDK version to use and looks like: `parentSlug-parentTag`, which would translate to `openjdk-8.0`
 
 ### Variants
 
@@ -122,7 +120,6 @@ For example, the tag `1.10` points to Clojure v1.10.1 now, but when the next rel
 `[-variant]` - Variant tags, if available, can optionally be used.
 Once the Node.js variant is available, it could be used like this: `cimg/clojure:1.10-node`.
 
-
 ## Development
 
 Images can be built and run locally with this repository.
@@ -181,6 +178,7 @@ docker run -it test/clojure:1.10.1-openjdk-8.0 bash
 ```
 
 If using the default version (latest), you could run either of the following:
+
 ```bash
 cd 1.10
 docker build -t test/clojure:1.10.1 .
@@ -244,7 +242,7 @@ git commit -m "Updating submodule for foo."
 This is to aid in "determinism" and prevent breaking customer builds.
 New Clojure images will automatically pick up the changes.
 
-If you *really* want to publish changes from a parent image into the Clojure image, you have to build a specific image version as if it was a new image.
+If you _really_ want to publish changes from a parent image into the Clojure image, you have to build a specific image version as if it was a new image.
 This will create a new Dockerfile and once published, a new image.
 
 **Clojure specific changes** - Editing the `Dockerfile.template` file in this repo is how to modify the Clojure image specifically.
@@ -256,20 +254,16 @@ We encourage [issues](https://github.com/CircleCI-Public/cimg-clojure/issues) an
 
 Please check out our [contributing guide](.github/CONTRIBUTING.md) which outlines best practices for contributions and what you can expect from the images team at CircleCI.
 
-
 ## Additional Resources
 
-[CircleCI Docs](https://circleci.com/docs/) - The official CircleCI Documentation website.  
+[CircleCI Docs](https://circleci.com/docs/) - The official CircleCI Documentation website.
 [CircleCI Configuration Reference](https://circleci.com/docs/2.0/configuration-reference/#section=configuration) - From CircleCI Docs, the configuration reference page is one of the most useful pages we have.
-It will list all of the keys and values supported in `.circleci/config.yml`.  
-[Docker Docs](https://docs.docker.com/) - For simple projects this won't be needed but if you want to dive deeper into learning Docker, this is a great resource.  
-
+It will list all of the keys and values supported in `.circleci/config.yml`.
+[Docker Docs](https://docs.docker.com/) - For simple projects this won't be needed but if you want to dive deeper into learning Docker, this is a great resource.
 
 ## License
 
 This repository is licensed under the MIT license.
 The license can be found [here](./LICENSE).
-
-
 
 [linux-version]: https://clojure.org/guides/install_clojure#_linux_instructions

--- a/build-images.sh
+++ b/build-images.sh
@@ -10,3 +10,6 @@ docker build --file 1.11/11.0/browsers/Dockerfile -t cimg/clojure:1.11.1-openjdk
 docker build --file 1.11/17.0/Dockerfile -t cimg/clojure:1.11.1-openjdk-17.0 -t cimg/clojure:1.11-openjdk-17.0 .
 docker build --file 1.11/17.0/node/Dockerfile -t cimg/clojure:1.11.1-openjdk-17.0-node -t cimg/clojure:1.11-openjdk-17.0-node .
 docker build --file 1.11/17.0/browsers/Dockerfile -t cimg/clojure:1.11.1-openjdk-17.0-browsers -t cimg/clojure:1.11-openjdk-17.0-browsers .
+docker build --file 1.11/21.0/Dockerfile -t cimg/clojure:1.11.1-openjdk-21.0 -t cimg/clojure:1.11-openjdk-21.0 .
+docker build --file 1.11/21.0/node/Dockerfile -t cimg/clojure:1.11.1-openjdk-21.0-node -t cimg/clojure:1.11-openjdk-21.0-node .
+docker build --file 1.11/21.0/browsers/Dockerfile -t cimg/clojure:1.11.1-openjdk-21.0-browsers -t cimg/clojure:1.11-openjdk-21.0-browsers .

--- a/manifest
+++ b/manifest
@@ -4,6 +4,6 @@ namespace=cimg
 repository=clojure
 parent=openjdk
 variants=(node browsers)
-parentTags=(8.0 11.0 17.0)
+parentTags=(8.0 11.0 17.0 21.0)
 defaultParentTag=17.0
 parentSlug=openjdk

--- a/push-images.sh
+++ b/push-images.sh
@@ -30,3 +30,9 @@ docker tag cimg/clojure:1.11.1-openjdk-17.0-browsers cimg/clojure:1.11.1-browser
 docker tag cimg/clojure:1.11-openjdk-17.0-browsers cimg/clojure:1.11-browsers
 docker push cimg/clojure:1.11-browsers
 docker push cimg/clojure:1.11.1-browsers
+docker push cimg/clojure:1.11-openjdk-21.0
+docker push cimg/clojure:1.11.1-openjdk-21.0
+docker push cimg/clojure:1.11-openjdk-21.0-node
+docker push cimg/clojure:1.11.1-openjdk-21.0-node
+docker push cimg/clojure:1.11-openjdk-21.0-browsers
+docker push cimg/clojure:1.11.1-openjdk-21.0-browsers


### PR DESCRIPTION
This only builds for Clojure 1.11.1, and does not change any versions from existing 1.11.1 images.

Clojure 1.11.2 is [around the corner](https://clojure.org/news/2023/10/20/clojure-1-12-alpha5) and versions can be upgraded for that release.

Fixes https://github.com/CircleCI-Public/cimg-clojure/issues/48
